### PR TITLE
Flush the pipe after having sent a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,11 @@ ones I referenced while developing my own's:
 
 ## Changelog
 
+### v0.2.1
+
+-   Ensure that commands sent to Gnuplot are executed immediately
+    ([#1](https://github.com/ziotom78/gplotpp/pull/1))
+
 ### v0.2.0
 
 -   New constants `GNUPLOTPP_VERSION`, `GNUPLOTPP_MAJOR_VERSION`,

--- a/example-simple.cpp
+++ b/example-simple.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "gplot++.h"
+#include <cstdio>
 #include <iostream>
 
 int main(void) {
@@ -33,4 +34,7 @@ int main(void) {
             << "\n";
   gnuplot.plot(x, y);
   gnuplot.show();
+
+  std::cout << "Press any key to quit...";
+  std::getchar();
 }

--- a/gplot++.h
+++ b/gplot++.h
@@ -50,7 +50,7 @@
 #include <unistd.h>
 #endif
 
-const unsigned GNUPLOTPP_VERSION = 0x000200;
+const unsigned GNUPLOTPP_VERSION = 0x000201;
 const unsigned GNUPLOTPP_MAJOR_VERSION = (GNUPLOTPP_VERSION & 0xFF0000) >> 16;
 const unsigned GNUPLOTPP_MINOR_VERSION = (GNUPLOTPP_VERSION & 0x00FF00) >> 8;
 const unsigned GNUPLOTPP_PATCH_VERSION = (GNUPLOTPP_VERSION & 0xFF);

--- a/gplot++.h
+++ b/gplot++.h
@@ -150,6 +150,8 @@ public:
 
     fputs(str, connection);
     fputc('\n', connection);
+    fflush(connection);
+
     return true;
   }
 


### PR DESCRIPTION
This commit forces the library to send commands to Gnuplot every time a `plot`, `histogram`, or `plot3d` method is invoked.

This enables the possibility to use the Gnuplot window interactively in `example-simple.cpp`. A call to `std::getchar` has been added to ensure that Gnuplot is still running if the user wants to interact with the window.

- Add `fflush` to Gnuplot::sendcommand
- Add a request for keypress in example-simple
