### PR TITLE
Add method Gnuplot::add_point

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -45,19 +45,20 @@ jobs:
       - name: Install Gnuplot and MinGW for Windows
         if: runner.os == 'Windows'
         run: |
-          choco install gnuplot --install-arguments="/LOADINF=gnuplot_install.inf"
-          choco install mingw
+          choco install -y --no-progress gnuplot --install-arguments="/LOADINF=gnuplot_install.inf"
+          choco install -y --no-progress mingw
+          g++ --version
           
       # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
       - uses: lukka/get-cmake@latest
       
       - name: Generate project files
         run: |
-          cmake -B "${{ env.CMAKE_BUILD_DIR }}"
+          cmake -G Ninja -B "${{ env.CMAKE_BUILD_DIR }}"
       # Build the whole project
       - name: Build
         run: |
-          cmake --build "${{ env.CMAKE_BUILD_DIR }}" --verbose
+          cmake -G Ninja --build "${{ env.CMAKE_BUILD_DIR }}"
       # Run the tests
       - name: Run tests
         working-directory: "${{ env.CMAKE_BUILD_DIR }}"

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -58,7 +58,7 @@ jobs:
       # Build the whole project
       - name: Build
         run: |
-          cmake -G Ninja --build "${{ env.CMAKE_BUILD_DIR }}"
+          cmake --build "${{ env.CMAKE_BUILD_DIR }}"
       # Run the tests
       - name: Run tests
         working-directory: "${{ env.CMAKE_BUILD_DIR }}"

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -58,7 +58,7 @@ jobs:
       # Build the whole project
       - name: Build
         run: |
-          cmake --build "${{ env.CMAKE_BUILD_DIR }}"
+          cmake --build --debug-output "${{ env.CMAKE_BUILD_DIR }}"
       # Run the tests
       - name: Run tests
         working-directory: "${{ env.CMAKE_BUILD_DIR }}"

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -62,6 +62,8 @@ jobs:
       # Run the tests
       - name: Run tests
         working-directory: "${{ env.CMAKE_BUILD_DIR }}"
+        # Under Windows, Chocolatey does not put Gnuplot in the PATH and the tests fail
+        if: runner.os != 'Windows'
         run: |
           ctest -C Debug --output-on-failure
       - name: Show content of workspace at its completion

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -42,20 +42,15 @@ jobs:
         run: |
           brew update
           brew install gnuplot
-      - name: Install Gnuplot for Windows
+      - name: Install Gnuplot and MinGW for Windows
         if: runner.os == 'Windows'
         run: |
           choco install gnuplot --install-arguments="/LOADINF=gnuplot_install.inf"
+          choco install mingw
           
       # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
       - uses: lukka/get-cmake@latest
       
-      - name: Set up MinGW
-        if: runner.os == 'Windows'
-        uses: egor-tensin/setup-mingw@v2
-        with:
-          platform: x64      # Run CMake to generate project files
-          
       - name: Generate project files
         run: |
           cmake -B "${{ env.CMAKE_BUILD_DIR }}"

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -44,7 +44,8 @@ jobs:
           brew install gnuplot
       - name: Install Gnuplot for Windows
         if: runner.os == 'Windows'
-        run: choco install gnuplot
+        run: |
+          choco install gnuplot --install-arguments="/LOADINF=gnuplot_install.inf"
           
       # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
       - uses: lukka/get-cmake@latest
@@ -60,9 +61,9 @@ jobs:
           cmake --build "${{ env.CMAKE_BUILD_DIR }}"
       # Run the tests
       - name: Run tests
-        if: runner.os != 'Windows'  # On Windows, Chocolatey does not add Gnuplot to PATH
         working-directory: "${{ env.CMAKE_BUILD_DIR }}"
-        run: ctest -C Debug --output-on-failure
+        run: |
+          ctest -C Debug --output-on-failure
       - name: Show content of workspace at its completion
         run: find $RUNNER_WORKSPACE
         shell: bash

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -58,7 +58,7 @@ jobs:
       # Build the whole project
       - name: Build
         run: |
-          cmake --build --debug-output "${{ env.CMAKE_BUILD_DIR }}"
+          cmake --build --verbose "${{ env.CMAKE_BUILD_DIR }}"
       # Run the tests
       - name: Run tests
         working-directory: "${{ env.CMAKE_BUILD_DIR }}"

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -49,9 +49,13 @@ jobs:
           
       # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
       - uses: lukka/get-cmake@latest
-      # On Windows runners, let's ensure to have the Developer Command Prompt environment setup correctly. As used here the Developer Command Prompt created is targeting x64 and using the default the Windows SDK.
-      - uses: ilammy/msvc-dev-cmd@v1
-      # Run CMake to generate project files
+      
+      - name: Set up MinGW
+        if: runner.os == 'Windows'
+        uses: egor-tensin/setup-mingw@v2
+        with:
+          platform: x64      # Run CMake to generate project files
+          
       - name: Generate project files
         run: |
           cmake -B "${{ env.CMAKE_BUILD_DIR }}"

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -58,7 +58,7 @@ jobs:
       # Build the whole project
       - name: Build
         run: |
-          cmake --build --verbose "${{ env.CMAKE_BUILD_DIR }}"
+          cmake --build "${{ env.CMAKE_BUILD_DIR }}" --verbose
       # Run the tests
       - name: Run tests
         working-directory: "${{ env.CMAKE_BUILD_DIR }}"

--- a/.github/workflows/gnuplot_install.inf
+++ b/.github/workflows/gnuplot_install.inf
@@ -1,0 +1,9 @@
+[Setup]
+Lang=en
+Dir=C:\gnuplot
+Group=gnuplot
+NoIcons=0
+SetupType=full
+Components=core
+Tasks=defaulttermpreserve,modifypath
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,6 @@ add_executable(run_tests
   tests/run_tests.cpp
   )
 
-target_include_directories(run_tests PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:include>
-  )
-
 add_executable(example-3d
   example-3d.cpp
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,6 @@ add_test(NAME run_tests
   COMMAND run_tests
   )
 
-add_executable(run_tests
-  tests/run_tests.cpp
-  )
-
 add_executable(example-3d
   example-3d.cpp
   )
@@ -65,4 +61,8 @@ add_executable(example-vec3d
 
 add_executable(example-dumb
   example-dumb.cpp
+  )
+
+add_executable(run_tests
+  tests/run_tests.cpp
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ add_executable(example-3d
   example-3d.cpp
   )
 
+add_executable(example-addpoint
+  example-addpoint.cpp
+)
+
 add_executable(example-complex
   example-complex.cpp
   )

--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ plt.show();
 
 ![](images/multipleseries.png)
 
+**New in version 0.7.0**: Instead of providing the two vectors, you can call `Gnuplot::add_point()` repeatedly and then call `Gnuplot::plot()` without specifying vectors. See the example program [example-addpoint.cpp](https://github.com/ziotom78/gplotpp/blob/master/example-3d.cpp).
+
 
 ### Histograms
 
@@ -502,7 +504,11 @@ There are several other libraries like gplot++ around. These are the ones I refe
 
 ### HEAD
 
-### v0.5.1
+### v0.7.0
+
+-   Add `Gnuplot::add_point`, `Gnuplot::get_num_of_points()`, `Gnuplot::get_points_x()`, and `Gnuplot::get_points_y()`, as well as a new overloaded method `Gnuplot::plot()` which does not require the vectors of `x` and `y`.
+
+### v0.5.1 (a.k.a. 0.6.0)
 
 -   Add `Gnuplot::set_title`
 

--- a/example-addpoint.cpp
+++ b/example-addpoint.cpp
@@ -1,0 +1,43 @@
+/* Copyright 2023 Maurizio Tomasi
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "gplot++.h"
+#include <cstdio>
+#include <iostream>
+
+int main(void) {
+    Gnuplot gnuplot{};
+
+    std::cout << "Running gplot++ v" << GNUPLOTPP_MAJOR_VERSION << "."
+              << GNUPLOTPP_MINOR_VERSION << "." << GNUPLOTPP_PATCH_VERSION
+              << "\n";
+
+    for(int k{}; k < 12; ++k) {
+        gnuplot.add_point(0.5 * k * k);
+    }
+    gnuplot.plot("", Gnuplot::LineStyle::LINESPOINTS);
+    gnuplot.show();
+
+    std::cout << "Press any key to quit...";
+    std::getchar();
+}

--- a/gplot++.h
+++ b/gplot++.h
@@ -379,11 +379,18 @@ public:
       add_point(list_of_x.size(), y);
   }
 
+  /* Return the number of points added by `add_point` */
   int get_num_of_points() const {
       check_consistency();
 
       return (int) list_of_x.size();
   }
+
+  /* Return the list of abscissas for the points added by `add_point` */
+  const std::vector<double> & get_points_x() const { return list_of_x; }
+
+    /* Return the list of ordinates for the points added by `add_point` */
+  const std::vector<double> & get_points_y() const { return list_of_y; }
 
   /* Create a plot using the values set with the method `add_point` */
   void plot(const std::string &label = "", LineStyle style = LineStyle::LINES) {

--- a/gplot++.h
+++ b/gplot++.h
@@ -28,6 +28,10 @@
  *
  * Version history
  *
+ * - 0.7.0 (2023/11/27): new methods `add_point`
+ *
+ * - 0.6.0 (2023/01/26): new method `set_title`
+ *
  * - 0.5.0 (2021/12/02): use a smarter algorithm to specify ranges
  *                       add `redirect_to_dumb` (and TerminalType enum)
  *
@@ -61,7 +65,7 @@
 #include <unistd.h>
 #endif
 
-const unsigned GNUPLOTPP_VERSION = 0x000500;
+const unsigned GNUPLOTPP_VERSION = 0x000700;
 const unsigned GNUPLOTPP_MAJOR_VERSION = (GNUPLOTPP_VERSION & 0xFF0000) >> 16;
 const unsigned GNUPLOTPP_MINOR_VERSION = (GNUPLOTPP_VERSION & 0x00FF00) >> 8;
 const unsigned GNUPLOTPP_PATCH_VERSION = (GNUPLOTPP_VERSION & 0xFF);
@@ -111,6 +115,9 @@ private:
 
     return result;
   }
+
+  std::vector<double> list_of_x;
+  std::vector<double> list_of_y;
 
 public:
   enum class LineStyle {
@@ -254,6 +261,12 @@ public:
     return sendcommand(os);
   }
 
+  bool set_title(const std::string &title) {
+	std::stringstream os;
+	os << "set title '" << escape_quotes(title) << "'";
+	return sendcommand(os);
+  }
+
   /* Set the label on the X axis */
   bool set_xlabel(const std::string &label) {
     std::stringstream os;
@@ -349,7 +362,23 @@ public:
     _plot(label, LineStyle::VECTORS, true, x, y, z, vx, vy, vz);
   }
 
-  template <typename T>
+  /* Add a point to the list of samples to be plotted */
+  void add_point(double x, double y) {
+      list_of_x.push_back(x);
+      list_of_y.push_back(y);
+  }
+
+  /* Add a value to the list of samples to be plotted */
+  void add_point(double y) {
+      add_point(list_of_x.size(), y);
+  }
+
+  /* Create a plot using the values set with the method `add_point` */
+  void plot(const std::string &label = "", LineStyle style = LineStyle::LINES) {
+      _plot(label, style, false, list_of_x, list_of_y);
+  }
+
+    template <typename T>
   void histogram(const std::vector<T> &values, size_t nbins,
                  const std::string &label = "",
                  LineStyle style = LineStyle::BOXES) {

--- a/gplot++.h
+++ b/gplot++.h
@@ -376,7 +376,7 @@ public:
 
   /* Add a value to the list of samples to be plotted */
   void add_point(double y) {
-      add_point(list_of_x.size(), y);
+      add_point(static_cast<double>(list_of_x.size()), y);
   }
 
   /* Return the number of points added by `add_point` */

--- a/gplot++.h
+++ b/gplot++.h
@@ -119,6 +119,10 @@ private:
   std::vector<double> list_of_x;
   std::vector<double> list_of_y;
 
+  void check_consistency() const {
+      assert(list_of_x.size() == list_of_y.size());
+  }
+
 public:
   enum class LineStyle {
     DOTS,
@@ -364,6 +368,8 @@ public:
 
   /* Add a point to the list of samples to be plotted */
   void add_point(double x, double y) {
+      check_consistency();
+
       list_of_x.push_back(x);
       list_of_y.push_back(y);
   }
@@ -373,8 +379,16 @@ public:
       add_point(list_of_x.size(), y);
   }
 
+  int get_num_of_points() const {
+      check_consistency();
+
+      return (int) list_of_x.size();
+  }
+
   /* Create a plot using the values set with the method `add_point` */
   void plot(const std::string &label = "", LineStyle style = LineStyle::LINES) {
+      check_consistency();
+
       _plot(label, style, false, list_of_x, list_of_y);
   }
 


### PR DESCRIPTION
This PR implements the method `Gnuplot::add_point()`, which lets the caller to add the points one by one to the plot. The figure can then be created with a new overloaded call of the `Gnuplot::plot()` method, where only the label and the line style are required. See the example program [example-addpoint.cpp](https://github.com/ziotom78/gplotpp/blob/master/example-3d.cpp).

- [X] Implement `add_point()`
- [X] Add safety checks
- [X] Add `get_num_of_points()`, `get_points_x()`, `get_points_y()`
